### PR TITLE
fingerprint: Speed up wake-and-unlock scenario

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardViewMediator.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardViewMediator.java
@@ -1842,10 +1842,15 @@ public class KeyguardViewMediator extends SystemUI {
                 playSounds(false);
             }
 
+	    boolean wakeAndUnlocking = mWakeAndUnlocking;
             mWakeAndUnlocking = false;
             setShowingLocked(false);
             mDismissCallbackRegistry.notifyDismissSucceeded();
-            mStatusBarKeyguardViewManager.hide(startTime, fadeoutDuration);
+	    if (wakeAndUnlocking) {
+		mStatusBarKeyguardViewManager.hideNoAnimation();
+	    } else {
+            	mStatusBarKeyguardViewManager.hide(startTime, fadeoutDuration);
+	    }
             resetKeyguardDonePendingLocked();
             mHideAnimationRun = false;
             adjustStatusBarLocked();

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/FingerprintUnlockController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/FingerprintUnlockController.java
@@ -253,7 +253,6 @@ public class FingerprintUnlockController extends KeyguardUpdateMonitorCallback {
                 }
                 mStatusBarWindowManager.setStatusBarFocusable(false);
                 mKeyguardViewMediator.onWakeAndUnlocking();
-                mScrimController.setWakeAndUnlocking();
                 mDozeScrimController.setWakeAndUnlocking();
                 if (mStatusBar.getNavigationBarView() != null) {
                     mStatusBar.getNavigationBarView().setWakeAndUnlocking(true);

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NavigationBarView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NavigationBarView.java
@@ -499,7 +499,7 @@ public class NavigationBarView extends FrameLayout implements PluginListener<Nav
     }
 
     public void setWakeAndUnlocking(boolean wakeAndUnlocking) {
-        setUseFadingAnimations(wakeAndUnlocking);
+        setUseFadingAnimations(!wakeAndUnlocking);
         mWakeAndUnlocking = wakeAndUnlocking;
         updateLayoutTransitionsEnabled();
     }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
@@ -2990,9 +2990,10 @@ public class StatusBar extends SystemUI implements DemoMode,
                 if (DEBUG_MEDIA) {
                     Log.v(TAG, "DEBUG_MEDIA: Fading out album artwork");
                 }
-                if (mFingerprintUnlockController.getMode()
-                        == FingerprintUnlockController.MODE_WAKE_AND_UNLOCK_PULSING
-                        || hideBecauseOccluded) {
+		int fpMode = mFingerprintUnlockController.getMode();
+		if (fpMode == FingerprintUnlockController.MODE_WAKE_AND_UNLOCK_PULSING ||
+			fpMode == FingerprintUnlockController.MODE_WAKE_AND_UNLOCK ||
+			hideBecauseOccluded) {
 
                     // We are unlocking directly - no animation!
                     mBackdrop.setVisibility(View.GONE);

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarKeyguardViewManager.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarKeyguardViewManager.java
@@ -479,6 +479,20 @@ public class StatusBarKeyguardViewManager implements RemoteInputController.Callb
         mBouncer.prepare();
     }
 
+    public void hideNoAnimation() {
+    	mShowing = false;
+    	mStatusBar.setKeyguardFadingAway(SystemClock.uptimeMillis(), 0, 0);
+    	mStatusBar.hideKeyguard();
+    	mStatusBar.finishKeyguardFadingAway();
+    	mStatusBarWindowManager.setKeyguardShowing(false);
+    	mBouncer.hide(true /* destroyView */);
+    	mViewMediatorCallback.keyguardGone();
+    	mFingerprintUnlockController.finishKeyguardFadingAway();
+    	updateStates();
+    	WindowManagerGlobal.getInstance().trimMemory(
+	    	ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN);
+    }
+
     private void animateScrimControllerKeyguardFadingOut(long delay, long duration,
             boolean skipFirstFrame) {
         animateScrimControllerKeyguardFadingOut(delay, duration, null /* endRunnable */,


### PR DESCRIPTION
* Directly dismiss keyguard instead of using a fade-out animation
* Skip virtual navigation button animation on wake

@xyyx: adapted to O

Change-Id: I053a3e7595f4d1456e627d3348f68e02b552efbc